### PR TITLE
Stdout and stderror decoding ignoring utf8 encoding errors

### DIFF
--- a/ffmpeg_normalize/_cmd_utils.py
+++ b/ffmpeg_normalize/_cmd_utils.py
@@ -64,10 +64,12 @@ def run_command(cmd, dry=False):
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True
+        universal_newlines=False
     )
     stdout, stderr = p.communicate()
 
+    stdout = stdout.decode("utf8", errors='replace')
+    stderr = stderr.decode("utf8", errors='replace')
     if p.returncode == 0:
         return (stdout + stderr)
     else:


### PR DESCRIPTION
Hello,

I made a fix because on last version, I found a case where stdout and stderror contains special chars that not decoded in utf8 by default on subprocess. This issue arrives in python3 not in python2. But with this patch I have no issue with the both python versions and unit test works.
Here is the command used: 

> ffmpeg-normalize -f issue_encoding.mp4 -nt peak -t 0 -c:a aac -o test.mp4

```

Invalid video file: Failed to normalize: Traceback (most recent call last):
File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
"__main__", mod_spec)
File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
exec(code, run_globals)
File "/usr/lib/python3/dist-packages/ffmpeg_normalize/__main__.py", line 338, in <module>
main()
File "/usr/lib/python3/dist-packages/ffmpeg_normalize/__main__.py", line 332, in main
ffmpeg_normalize.add_media_file(input_file, output_file)
File "/usr/lib/python3/dist-packages/ffmpeg_normalize/_ffmpeg_normalize.py", line 163, in add_media_file
mf = MediaFile(self, input_file, output_file)
File "/usr/lib/python3/dist-packages/ffmpeg_normalize/_media_file.py", line 40, in __init__
self.parse_streams()
File "/usr/lib/python3/dist-packages/ffmpeg_normalize/_media_file.py", line 62, in parse_streams
output = run_command(cmd)
File "/usr/lib/python3/dist-packages/ffmpeg_normalize/_cmd_utils.py", line 69, in run_command
stdout, stderr = p.communicate()
File "/usr/lib/python3.5/subprocess.py", line 1072, in communicate
stdout, stderr = self._communicate(input, endtime, timeout)
File "/usr/lib/python3.5/subprocess.py", line 1757, in _communicate
self.stderr.encoding)
File "/usr/lib/python3.5/subprocess.py", line 976, in _translate_newlines
data = data.decode(encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 1692: invalid continuation byte
, failed to normalize it
```
You can download the media that contains special chars [here](https://www.ubicast.eu/media/downloads/videos/issue_encoding.mp4)

Regards,

Anthony


