### PR TITLE
Stderror decoding ignoring utf8 encoding errors

### DIFF
--- a/ffmpeg_normalize/_cmd_utils.py
+++ b/ffmpeg_normalize/_cmd_utils.py
@@ -63,12 +63,12 @@ class CommandRunner():
             self.cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True
+            universal_newlines=False
         )
 
         # for stderr_line in iter(p.stderr):
         while True:
-            line = p.stderr.readline()
+            line = p.stderr.readline().decode("utf8", errors='replace')
             if line == '' and p.poll() is not None:
                 break
             stderr.append(line.strip())


### PR DESCRIPTION
Hello,

I made a fix because on last version, I found the same issue that last time with special chars taht not decoded in utf8 by default on subprocess for run_ffmpeg_command function.
Here is the command used:

`ffmpeg-normalize -f issue_encoding.mp4 -nt peak -t 0 -c:a aac -o test.mp4`
`Traceback (most recent call last):
  File "/usr/local/bin/ffmpeg-normalize", line 9, in <module>
    load_entry_point('ffmpeg-normalize==1.3.1', 'console_scripts', 'ffmpeg-normalize')()
  File "/usr/local/lib/python3.5/dist-packages/ffmpeg_normalize-1.3.1-py3.5.egg/ffmpeg_normalize/__main__.py", line 346, in main
    ffmpeg_normalize.run_normalization()
  File "/usr/local/lib/python3.5/dist-packages/ffmpeg_normalize-1.3.1-py3.5.egg/ffmpeg_normalize/_ffmpeg_normalize.py", line 186, in run_normalization
    media_file.run_normalization()
  File "/usr/local/lib/python3.5/dist-packages/ffmpeg_normalize-1.3.1-py3.5.egg/ffmpeg_normalize/_media_file.py", line 120, in run_normalization
    self._first_pass()
  File "/usr/local/lib/python3.5/dist-packages/ffmpeg_normalize-1.3.1-py3.5.egg/ffmpeg_normalize/_media_file.py", line 153, in _first_pass
    for _ in fun():
  File "/usr/local/lib/python3.5/dist-packages/ffmpeg_normalize-1.3.1-py3.5.egg/ffmpeg_normalize/_streams.py", line 149, in parse_loudnorm_stats
    for progress in cmd_runner.run_ffmpeg_command():
  File "/usr/local/lib/python3.5/dist-packages/ffmpeg_normalize-1.3.1-py3.5.egg/ffmpeg_normalize/_cmd_utils.py", line 71, in run_ffmpeg_command
    line = p.stderr.readline()
  File "/usr/lib/python3.5/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 333: invalid continuation byte`

You can try with the same media a sent you last patch.

Regards,

Anthony