### PR TITLE
Run prefilters in first pass too

### DIFF
--- a/ffmpeg_normalize/_streams.py
+++ b/ffmpeg_normalize/_streams.py
@@ -155,7 +155,7 @@ class AudioStream(MediaStream):
             opts['dual_mono'] = 'true'
 
         filter_str = '[0:{}]'.format(self.stream_id) + \
-            'loudnorm=' + dict_to_filter_opts(opts)
+            self.ffmpeg_normalize.pre_filter + ',' + 'loudnorm=' + dict_to_filter_opts(opts)
 
         cmd = [
             self.media_file.ffmpeg_normalize.ffmpeg_exe, '-nostdin', '-y',


### PR DESCRIPTION
Add prefilters to first pass too, because prefilter can change
overall levels (eg. dynaudnorm or normalize) and thus affect the amount of gain
applied to loudness normalization.

Post filters are not necessary here, but changes introduced by them will be introduced after the second pass.