### PR TITLE
Fix typo in README's table of contents link to "File Input/Output".

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contents:
 - [Description](#description)
 - [Examples](#examples)
 - [Detailed Options](#detailed-options)
-    - [File Input/Output](#file-input-output)
+    - [File Input/Output](#file-inputoutput)
     - [General](#general)
     - [Normalization](#normalization)
     - [EBU R128 Normalization](#ebu-r128-normalization)


### PR DESCRIPTION
The link to "File Input/Output" in the README's table of contents wasn't working because Github replaces the slash with an empty-string (not a space) in the href.