### PR TITLE
Fixing stdin corruption caused by new subprocess

### DIFF
--- a/ffmpeg_normalize/_cmd_utils.py
+++ b/ffmpeg_normalize/_cmd_utils.py
@@ -62,6 +62,7 @@ class CommandRunner():
 
         p = subprocess.Popen(
             cmd_with_progress,
+            stdin=subprocess.PIPE,    # Apply stdin isolation by creating separate pipe.
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=False
@@ -99,6 +100,7 @@ class CommandRunner():
 
         p = subprocess.Popen(
             self.cmd,
+            stdin=subprocess.PIPE,    # Apply stdin isolation by creating separate pipe.
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=False


### PR DESCRIPTION
Hi @slhck ,

I found source of issue https://github.com/slhck/ffmpeg-normalize/issues/135 . Subprocess started by python with ffmpeg is causing corruption in stdin pipe, which reads lines in bash `while read line`. It is reading first byte from stdin pipe, causing missing `.` from path. It is similar case to old python subprocess module bug (https://blog.nelhage.com/2010/02/a-very-subtle-bug/). It is not the same, but similar - kind of side effect of over pipes for complex process chain.

This pull request contain minimal fix. I've tested it on python 2.7 / 3.7 and problem is solved. I was able to reproduce it before fix. 