### PR TITLE
Set tqdm lock for logging only when multiprocessing is available 

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -2,7 +2,10 @@
 
 ## Tests
 
-See `test/test.py`.
+Tests are located in `test/test.py`. To run them:
+
+- Install `requirements.txt` and `requirements.dev.txt`
+- Run `pytest test/test.py`
 
 ## Making Releases
 

--- a/ffmpeg_normalize/_logger.py
+++ b/ffmpeg_normalize/_logger.py
@@ -1,7 +1,6 @@
 import logging
 from platform import system
 from tqdm import tqdm
-from multiprocessing import Lock
 import sys
 
 loggers = {}
@@ -15,7 +14,7 @@ class TqdmLoggingHandler(logging.StreamHandler):
     def emit(self, record):
         try:
             msg = self.format(record)
-            tqdm.set_lock(Lock())
+            set_mp_lock()
             tqdm.write(msg, file=sys.stderr)
             self.flush()
         except (KeyboardInterrupt, SystemExit):
@@ -23,6 +22,14 @@ class TqdmLoggingHandler(logging.StreamHandler):
         except Exception:
             self.handleError(record)
 
+def set_mp_lock():
+    try:
+        from multiprocessing import Lock
+        tqdm.set_lock(Lock())
+    except (ImportError, OSError):
+        # Some python environments do not support multiprocessing
+        # See: https://github.com/slhck/ffmpeg-normalize/issues/156
+        pass
 
 def setup_custom_logger(name):
     """


### PR DESCRIPTION
Multiprocessing is not available in all environments, for example on AWS lambda python run time lacks `/dev/shm`, so trying to acquire a multiprocessing Lock throws an OSError.

The module could also be entirely missing in some cases (ex. Jython, although this library doesn't support Jython anyway because Jython only supports up to python 2.7).

The solution to this is to only try to set the lock when multiprocessing is available. The `tqdm` library solves this in the same manner.

For more details, see: #156