### PR TITLE
use astats instead of volumedetect filter, fixes #163

### DIFF
--- a/ffmpeg_normalize/_media_file.py
+++ b/ffmpeg_normalize/_media_file.py
@@ -169,7 +169,7 @@ class MediaFile:
             if self.ffmpeg_normalize.normalization_type == "ebu":
                 fun = getattr(audio_stream, "parse_loudnorm_stats")
             else:
-                fun = getattr(audio_stream, "parse_volumedetect_stats")
+                fun = getattr(audio_stream, "parse_astats")
 
             if self.ffmpeg_normalize.progress:
                 with tqdm(


### PR DESCRIPTION
Allows floating point calculation.
See: https://github.com/slhck/ffmpeg-normalize/issues/163