### PR TITLE
remove unnecessary utf-8 declarations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from setuptools import setup
 
-# To use a consistent encoding
-from codecs import open
 from os import path
+
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 
@@ -13,11 +11,11 @@ with open(path.join(here, "ffmpeg_normalize", "_version.py")) as version_file:
     version = eval(version_file.read().split("=")[1].strip())
 
 # Get the long description from the README file
-with open(path.join(here, "README.md"), encoding="utf-8") as f:
+with open(path.join(here, "README.md")) as f:
     long_description = f.read()
 
 # Get the history from the CHANGELOG file
-with open(path.join(here, "CHANGELOG.md"), encoding="utf-8") as f:
+with open(path.join(here, "CHANGELOG.md")) as f:
     history = f.read()
 
 setup(


### PR DESCRIPTION
"-*- coding: utf-8 -*-" is a Python 2 construct and can be safely removed. Other utf-8 declarations are also unnecessary.