### PR TITLE
Remove manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include CHANGELOG.md
-include README.md
-include CONTRIBUTING.md
-include LICENSE
-include setup.cfg
-include test/*


### PR DESCRIPTION
MANIFEST.in's are outdated and can safely be deleted without any other change.

 - `CHANGELOG.md` is redundant since the description already includes that information
 - The `CONTRIBUTING.md` file doesn't exist 
 - The `test` directory shouldn't be included because it does nothing for the user and adds 3.2M of unneeded storage space
 - `setup.cfg`, `README.md`, and `LICENSE` are automatically added during packaging
