### PR TITLE
refactor: Improved logging behavior

### DIFF
--- a/ffmpeg_normalize/__init__.py
+++ b/ffmpeg_normalize/__init__.py
@@ -4,6 +4,8 @@ from ._media_file import MediaFile
 from ._streams import AudioStream, MediaStream, SubtitleStream, VideoStream
 from ._version import __version__
 
+__module_name__ = "ffmpeg_normalize"
+
 __all__ = [
     "FFmpegNormalize",
     "FFmpegNormalizeError",

--- a/ffmpeg_normalize/__main__.py
+++ b/ffmpeg_normalize/__main__.py
@@ -12,10 +12,10 @@ from typing import NoReturn
 
 from ._errors import FFmpegNormalizeError
 from ._ffmpeg_normalize import NORMALIZATION_TYPES, FFmpegNormalize
-from ._logger import setup_custom_logger
+from ._logger import setup_cli_logger
 from ._version import __version__
 
-logger = setup_custom_logger()
+_logger = logging.getLogger(__name__)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -442,19 +442,13 @@ def create_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     cli_args = create_parser().parse_args()
-
-    if cli_args.quiet:
-        logger.setLevel(logging.ERROR)
-    elif cli_args.debug:
-        logger.setLevel(logging.DEBUG)
-    elif cli_args.verbose:
-        logger.setLevel(logging.INFO)
+    setup_cli_logger(arguments=cli_args)
 
     def error(message: object) -> NoReturn:
-        if logger.getEffectiveLevel() == logging.DEBUG:
-            logger.error(f"FFmpegNormalizeError: {message}")
+        if _logger.getEffectiveLevel() == logging.DEBUG:
+            _logger.error(f"FFmpegNormalizeError: {message}")
         else:
-            logger.error(message)
+            _logger.error(message)
         sys.exit(1)
 
     def _split_options(opts: str) -> list[str]:
@@ -515,7 +509,7 @@ def main() -> None:
     )
 
     if cli_args.output and len(cli_args.input) > len(cli_args.output):
-        logger.warning(
+        _logger.warning(
             "There are more input files than output file names given. "
             "Please specify one output file name per input file using -o <output1> <output2> ... "
             "Will apply default file naming for the remaining ones."
@@ -524,7 +518,7 @@ def main() -> None:
     for index, input_file in enumerate(cli_args.input):
         if cli_args.output is not None and index < len(cli_args.output):
             if cli_args.output_folder and cli_args.output_folder != "normalized":
-                logger.warning(
+                _logger.warning(
                     f"Output folder {cli_args.output_folder} is ignored for "
                     f"input file {input_file}"
                 )
@@ -540,7 +534,7 @@ def main() -> None:
                 + cli_args.extension,
             )
             if not os.path.isdir(cli_args.output_folder) and not cli_args.dry_run:
-                logger.warning(
+                _logger.warning(
                     f"Output directory '{cli_args.output_folder}' does not exist, will create"
                 )
                 os.makedirs(cli_args.output_folder, exist_ok=True)

--- a/ffmpeg_normalize/_cmd_utils.py
+++ b/ffmpeg_normalize/_cmd_utils.py
@@ -11,9 +11,8 @@ from typing import Iterator
 from ffmpeg_progress_yield import FfmpegProgress
 
 from ._errors import FFmpegNormalizeError
-from ._logger import setup_custom_logger
 
-logger = setup_custom_logger()
+_logger = logging.getLogger(__name__)
 
 NUL = "NUL" if system() in ("Windows", "cli") else "/dev/null"
 DUR_REGEX = re.compile(
@@ -75,14 +74,14 @@ class CommandRunner:
             int: Progress percentage
         """
         # wrapper for 'ffmpeg-progress-yield'
-        logger.debug(f"Running command: {cmd}")
+        _logger.debug(f"Running command: {cmd}")
         ff = FfmpegProgress(cmd, dry_run=self.dry)
         yield from ff.run_command_with_progress()
 
         self.output = ff.stderr
 
-        if logger.getEffectiveLevel() == logging.DEBUG and self.output is not None:
-            logger.debug(
+        if _logger.getEffectiveLevel() == logging.DEBUG and self.output is not None:
+            _logger.debug(
                 f"ffmpeg output: {CommandRunner.prune_ffmpeg_progress_from_output(self.output)}"
             )
 
@@ -97,10 +96,10 @@ class CommandRunner:
         Raises:
             RuntimeError: If command returns non-zero exit code
         """
-        logger.debug(f"Running command: {cmd}")
+        _logger.debug(f"Running command: {cmd}")
 
         if self.dry:
-            logger.debug("Dry mode specified, not actually running command")
+            _logger.debug("Dry mode specified, not actually running command")
             return self
 
         p = subprocess.Popen(
@@ -187,7 +186,7 @@ def ffmpeg_has_loudnorm() -> bool:
     output = CommandRunner().run_command([get_ffmpeg_exe(), "-filters"]).get_output()
     supports_loudnorm = "loudnorm" in output
     if not supports_loudnorm:
-        logger.error(
+        _logger.error(
             "Your ffmpeg does not support the 'loudnorm' filter. "
             "Please make sure you are running ffmpeg v4.2 or above."
         )

--- a/ffmpeg_normalize/_ffmpeg_normalize.py
+++ b/ffmpeg_normalize/_ffmpeg_normalize.py
@@ -2,19 +2,20 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from typing import TYPE_CHECKING, Literal
 
 from tqdm import tqdm
 
 from ._cmd_utils import ffmpeg_has_loudnorm, get_ffmpeg_exe
 from ._errors import FFmpegNormalizeError
-from ._logger import setup_custom_logger
+
 from ._media_file import MediaFile
 
 if TYPE_CHECKING:
     from ._streams import LoudnessStatisticsWithMetadata
 
-logger = setup_custom_logger()
+_logger = logging.getLogger(__name__)
 
 NORMALIZATION_TYPES = ("ebu", "rms", "peak")
 PCM_INCOMPATIBLE_FORMATS = {"flac", "mp3", "mp4", "ogg", "oga", "opus", "webm"}
@@ -142,7 +143,7 @@ class FFmpegNormalize:
         self.keep_loudness_range_target = keep_loudness_range_target
 
         if self.keep_loudness_range_target and loudness_range_target != 7.0:
-            logger.warning(
+            _logger.warning(
                 "Setting --keep-loudness-range-target will override your set loudness range target value! "
                 "Remove --keep-loudness-range-target or remove the --lrt/--loudness-range-target option."
             )
@@ -219,7 +220,7 @@ class FFmpegNormalize:
         for index, media_file in enumerate(
             tqdm(self.media_files, desc="File", disable=not self.progress, position=0)
         ):
-            logger.info(
+            _logger.info(
                 f"Normalizing file {media_file} ({index + 1} of {self.file_count})"
             )
 
@@ -228,7 +229,7 @@ class FFmpegNormalize:
             except Exception as e:
                 if len(self.media_files) > 1:
                     # simply warn and do not die
-                    logger.error(
+                    _logger.error(
                         f"Error processing input file {media_file}, will "
                         f"continue batch-processing. Error was: {e}"
                     )
@@ -236,7 +237,7 @@ class FFmpegNormalize:
                     # raise the error so the program will exit
                     raise e
 
-            logger.info(f"Normalized file written to {media_file.output_file}")
+            _logger.info(f"Normalized file written to {media_file.output_file}")
 
         if self.print_stats and self.stats:
             print(json.dumps(self.stats, indent=4))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tqdm>=4.64.1
 colorama>=0.4.6
 ffmpeg-progress-yield>=0.5.0
+colorlog==6.7.0


### PR DESCRIPTION
This PR improves the logging behavior of **ffmpeg-normalize** when used via API/python import.

With the current implementation, the logging configuration of **ffmpeg-normalize** overwrites the root logging behavior even if it's used via python import. For example, the (now deleted) section

```python
if system() not in ("Windows", "cli"):
    logging.addLevelName(logging.ERROR, "[1;31mERROR[1;0m")
    logging.addLevelName(logging.WARNING, "[1;33mWARNING[1;0m")
    logging.addLevelName(logging.INFO, "[1;34mINFO[1;0m")
    logging.addLevelName(logging.DEBUG, "[1;35mDEBUG[1;0m")
```
added the ANSI color codes to all log messages and the entire output of **ffmpeg-normalize** is put into the log of the application that imports it. However, in most cases the developers might want to configure this behavior.

With this implementation, you can choose whether or whether not to use the logging output of **ffmpeg-normalize**. To enable the log output, the following code section (or similar) is necessary:

```python

# handler is defined by your application
ffmpeg_logger = logging.getLogger('ffmpeg_normalize')
ffmpeg_logger.addHandler(handler)
ffmpeg_logger.setLevel("DEBUG")
```

Please note that the CLI logging behavior of **ffmpeg-normalize** doesn't change with this PR. I'm configuring the logger in the CLI entrypoint in the same way as it was before (with the help of [colorlog](https://github.com/borntyping/python-colorlog)
