### PR TITLE
Add "-hide_banner" remove "-nostdin"

### DIFF
--- a/ffmpeg_normalize/_media_file.py
+++ b/ffmpeg_normalize/_media_file.py
@@ -289,7 +289,7 @@ class MediaFile:
             output_stream_types.append("subtitle")
 
         # base command, here we will add all other options
-        cmd = [self.ffmpeg_normalize.ffmpeg_exe, "-y", "-nostdin"]
+        cmd = [self.ffmpeg_normalize.ffmpeg_exe, "-hide_banner", "-y"]
 
         # extra options (if any)
         if self.ffmpeg_normalize.extra_input_options:

--- a/ffmpeg_normalize/_streams.py
+++ b/ffmpeg_normalize/_streams.py
@@ -226,7 +226,7 @@ class AudioStream(MediaStream):
 
         cmd = [
             self.media_file.ffmpeg_normalize.ffmpeg_exe,
-            "-nostdin",
+            "-hide_banner",
             "-y",
             "-i",
             self.media_file.input_file,
@@ -295,7 +295,7 @@ class AudioStream(MediaStream):
 
         cmd = [
             self.media_file.ffmpeg_normalize.ffmpeg_exe,
-            "-nostdin",
+            "-hide_banner",
             "-y",
             "-i",
             self.media_file.input_file,


### PR DESCRIPTION
The `-nostdin` option is unnessary because of the `-y` option. Adding `-hide_banner` makes DEBUG statements shorter.