### PR TITLE
feat: add linear loudnorm option to set lra up to target, then keep input lra

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ Some containers (like MP4) also cannot handle PCM audio. If you want to use such
 
 - `--keep-loudness-range-target`: Keep the input loudness range target to allow for linear normalization.
 
+- `--keep-lra-above-loudness-range-target`: Keep input loudness range above loudness range target.
+
+  - `LOUDNESS_RANGE_TARGET` for input loudness range `<= LOUDNESS_RANGE_TARGET` or
+  - keep input loudness range target above `LOUDNESS_RANGE_TARGET`.
+
+  as alternative to `--keep-loudness-range-target` to allow for linear normalization.
+
 - `-tp TRUE_PEAK, --true-peak TRUE_PEAK`: EBU Maximum True Peak in dBTP (default: -2.0).
 
     Range is -9.0 - +0.0.

--- a/ffmpeg_normalize/__main__.py
+++ b/ffmpeg_normalize/__main__.py
@@ -195,6 +195,19 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     group_ebu.add_argument(
+        "--keep-lra-above-loudness-range-target",
+        action="store_true",
+        help=textwrap.dedent(
+            """\
+        Keep input loudness range above loudness range target.
+        - `LOUDNESS_RANGE_TARGET` for input loudness range `<= LOUDNESS_RANGE_TARGET` or
+        - keep input loudness range target above `LOUDNESS_RANGE_TARGET`.
+        as alternative to `--keep-loudness-range-target` to allow for linear normalization.
+        """
+        ),
+    )
+
+    group_ebu.add_argument(
         "-tp",
         "--true-peak",
         type=float,
@@ -486,6 +499,7 @@ def main() -> None:
         loudness_range_target=cli_args.loudness_range_target,
         # threshold=cli_args.threshold,
         keep_loudness_range_target=cli_args.keep_loudness_range_target,
+        keep_lra_above_loudness_range_target=cli_args.keep_lra_above_loudness_range_target,
         true_peak=cli_args.true_peak,
         offset=cli_args.offset,
         dual_mono=cli_args.dual_mono,

--- a/ffmpeg_normalize/_ffmpeg_normalize.py
+++ b/ffmpeg_normalize/_ffmpeg_normalize.py
@@ -55,6 +55,7 @@ class FFmpegNormalize:
         print_stats (bool, optional): Print loudnorm stats. Defaults to False.
         loudness_range_target (float, optional): Loudness range target. Defaults to 7.0.
         keep_loudness_range_target (bool, optional): Keep loudness range target. Defaults to False.
+        keep_lra_above_loudness_range_target (bool, optional): Keep input loudness range above loudness range target. Defaults to False.
         true_peak (float, optional): True peak. Defaults to -2.0.
         offset (float, optional): Offset. Defaults to 0.0.
         dual_mono (bool, optional): Dual mono. Defaults to False.
@@ -89,6 +90,7 @@ class FFmpegNormalize:
         # threshold=0.5,
         loudness_range_target: float = 7.0,
         keep_loudness_range_target: bool = False,
+        keep_lra_above_loudness_range_target: bool = False,
         true_peak: float = -2.0,
         offset: float = 0.0,
         dual_mono: bool = False,
@@ -145,6 +147,14 @@ class FFmpegNormalize:
             _logger.warning(
                 "Setting --keep-loudness-range-target will override your set loudness range target value! "
                 "Remove --keep-loudness-range-target or remove the --lrt/--loudness-range-target option."
+            )
+
+        self.keep_lra_above_loudness_range_target = keep_lra_above_loudness_range_target
+
+        if self.keep_loudness_range_target and self.keep_lra_above_loudness_range_target:
+            raise FFmpegNormalizeError(
+                "Options --keep-loudness-range-target and --keep-lra-above-loudness-range-target are partially contradictory! "
+                "Please choose just one of the two options"
             )
 
         self.true_peak = check_range(true_peak, -9, 0, name="true_peak")

--- a/ffmpeg_normalize/_streams.py
+++ b/ffmpeg_normalize/_streams.py
@@ -411,6 +411,19 @@ class AudioStream(MediaStream):
                 self.loudness_statistics["ebu"]["input_lra"]
             )
 
+        if self.media_file.ffmpeg_normalize.keep_lra_above_loudness_range_target:
+            if self.loudness_statistics["ebu"]["input_lra"] <= self.media_file.ffmpeg_normalize.loudness_range_target:
+                _logger.debug(
+                    "Setting loudness range target in second pass loudnorm filter"
+                )
+            else:
+                self.media_file.ffmpeg_normalize.loudness_range_target = (
+                    self.loudness_statistics["ebu"]["input_lra"]
+                )
+                _logger.debug(
+                    "Keeping target loudness range in second pass loudnorm filter"
+                )
+
         if (
             self.media_file.ffmpeg_normalize.loudness_range_target
             < self.loudness_statistics["ebu"]["input_lra"]
@@ -420,7 +433,8 @@ class AudioStream(MediaStream):
                 f"Input file had loudness range of {self.loudness_statistics['ebu']['input_lra']}. "
                 f"This is larger than the loudness range target ({self.media_file.ffmpeg_normalize.loudness_range_target}). "
                 "Normalization will revert to dynamic mode. Choose a higher target loudness range if you want linear normalization. "
-                "Alternatively, use the --keep-loudness-range-target option to keep the target loudness range from the input."
+                "Alternatively, use the --keep-loudness-range-target or --keep-lra-above-loudness-range-target option to keep the target loudness range from "
+                "the input."
             )
             will_use_dynamic_mode = True
 


### PR DESCRIPTION
This aims to fix #227 

- Adds Option `--keep-lra-above-loudness-range-target` that may be used instead of `--keep-loudness-range-target`.
  the new option `--keep-lra-above-loudness-range-target` sets loudness range target (e.g. the default `7.0`) for all input files that already have an LRA of less than the loudness range target. But behaves the same as `--keep-loudness-range-target` for higher input LRAs

  This automatically solves an issue with `--keep-loudness-range-target` for input files with LRA less than `1`, where `ffmpeg` only allows `LRA` within the range `[1, 50]`.

- The usage of both flags together is restricted with raising an error, as for `LRA` lower than the set `--loudness-range-target` one flag would else need to be silently ignored.

I hope it is ok, that I added a description of this option to the `argparser` and the ReadMe.

I tried to pick up your style. Please feel free to correct anything that does not fit your point of view. I will correct it. In case of necessary corrections please tell me if I should force push the changes to the same commit (in order to not create multiple commits) or if I should simply do another commit.

Hope you like it :)