### PR TITLE
fix capping to [1, 50] instead of [1, 7]

### DIFF
--- a/ffmpeg_normalize/_streams.py
+++ b/ffmpeg_normalize/_streams.py
@@ -408,14 +408,14 @@ class AudioStream(MediaStream):
                 "Keeping target loudness range in second pass loudnorm filter"
             )
             input_lra = self.loudness_statistics["ebu"]["input_lra"]
-            if input_lra < 1 or input_lra > 7:
+            if input_lra < 1 or input_lra > 50:
                 _logger.warning(
-                    "Input file had measured loudness range outside of [1,7] "
+                    "Input file had measured loudness range outside of [1,50] "
                     f"({input_lra}), capping to allowed range"
                 )
 
             self.media_file.ffmpeg_normalize.loudness_range_target = self._constrain(
-                self.loudness_statistics["ebu"]["input_lra"], 1, 7
+                self.loudness_statistics["ebu"]["input_lra"], 1, 50
             )
 
         if self.media_file.ffmpeg_normalize.keep_lra_above_loudness_range_target:


### PR DESCRIPTION
One of the last commits introduced a capping of `input_lra` to `[1, 7]`, but this has issues with songs having `input_lra > 7` as setting a lower `LRA` than `input_lra` forces `ffmpeg` to `Dynamic` loudness correction. (I guess it was a mind-twist with the `LRA=7.0` required for the EBU Standard.)

I hope it is ok that I directly created a PR, but as this breaks the `--keep-loudness-range-target` flag, I wanted to introduce a fix as soon as I saw and validated the issue.

If I am wrong, please just close the PR. In this case I am sorry for the hassle.