### PR TITLE
ci: skip ci tests for commits that change only markdown files

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,8 @@ name: Test Package
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
### Change Summary
Currently, the `Test Package` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`c141666`](https://github.com/slhck/ffmpeg-normalize/commit/c141666818324329b6b0ad7f41f22f0bb5c30f85) changed these files: `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/question.md` and, when pushed, triggered [this](https://github.com/slhck/ffmpeg-normalize/actions/runs/13050147417) workflow run, which ran for ~7 CPU minutes. With the proposed changes, these 7 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 7 examples over the last few months; an estimate for the accumulated gain is around **1 CPU hour**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit c141666](https://github.com/slhck/ffmpeg-normalize/commit/c141666) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/13050147417)
[commit 18f37a1](https://github.com/slhck/ffmpeg-normalize/commit/18f37a1) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/12251855563)
[commit effdaf7](https://github.com/slhck/ffmpeg-normalize/commit/effdaf7) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/9627309890)
[commit 1c2e41b](https://github.com/slhck/ffmpeg-normalize/commit/1c2e41b) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/9644143906)
[commit fad3a22](https://github.com/slhck/ffmpeg-normalize/commit/fad3a22) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/14476515076)
[commit 6a32876](https://github.com/slhck/ffmpeg-normalize/commit/6a32876) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/11928960025)
[commit 6fa83be](https://github.com/slhck/ffmpeg-normalize/commit/6fa83be) => [run url](https://github.com/slhck/ffmpeg-normalize/actions/runs/14477169925)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch