### PR TITLE
feat: add selective audio stream normalization

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -187,6 +187,32 @@ Set the number of audio channels. If not specified, the input channel layout wil
 
 Copy original, non-normalized audio streams to output file
 
+## Audio Stream Selection
+
+### `-as AUDIO_STREAMS, --audio-streams AUDIO_STREAMS`
+
+Select specific audio streams to normalize by stream index (comma-separated).
+
+Example: `-as 1` normalizes only stream 1, `-as 1,2` normalizes streams 1 and 2.
+
+If not specified, all audio streams will be normalized (default behavior).
+
+### `--audio-default-only`
+
+Only normalize audio streams with the 'default' disposition flag.
+
+This is useful for files with multiple audio tracks where only the default track should be normalized (e.g., main audio track vs. commentary tracks).
+
+### `--keep-other-audio`
+
+Keep non-selected audio streams in the output file (copy without normalization).
+
+Must be combined with either `-as`/`--audio-streams` or `--audio-default-only`.
+
+Example: `ffmpeg-normalize input.mkv -as 1 --keep-other-audio` will normalize stream 1 and copy all other audio streams unchanged.
+
+**Note:** This option is mutually exclusive with `--keep-original-audio`. Use `--keep-original-audio` to keep all original streams alongside normalized ones, or `--keep-other-audio` to keep only non-selected streams as passthrough.
+
 ### `-prf PRE_FILTER, --pre-filter PRE_FILTER`
 
 Add an audio filter chain before applying normalization.

--- a/src/ffmpeg_normalize/_streams.py
+++ b/src/ffmpeg_normalize/_streams.py
@@ -99,6 +99,7 @@ class AudioStream(MediaStream):
         sample_rate: int | None,
         bit_depth: int | None,
         duration: float | None,
+        is_default: bool = False,
     ):
         """
         Create an AudioStream object.
@@ -110,6 +111,7 @@ class AudioStream(MediaStream):
             sample_rate (int): sample rate in Hz
             bit_depth (int): bit depth in bits
             duration (float): duration in seconds
+            is_default (bool): Whether this stream has the default disposition flag
         """
         super().__init__(ffmpeg_normalize, media_file, "audio", stream_id)
 
@@ -124,6 +126,7 @@ class AudioStream(MediaStream):
         self.bit_depth = bit_depth
 
         self.duration = duration
+        self.is_default = is_default
 
     @staticmethod
     def _constrain(


### PR DESCRIPTION
Add support for selective audio stream normalization, addressing issue #285.

New CLI arguments:

- `-as/--audio-streams`: Select specific audio streams by index (comma-separated)
- `--audio-default-only`: Only normalize audio streams with 'default' disposition
- `--keep-other-audio`: Keep non-selected streams as passthrough (unchanged)

Implementation details:

- Added `is_default` flag to AudioStream to track disposition
- Updated MediaFile.parse_streams() to parse "(default)" flag from FFmpeg output
- Added _get_streams_to_normalize() method to filter streams based on selection
- Updated first pass, filter generation, and second pass for selected + passthrough streams
- Proper output stream index tracking for correct codec assignment

Validation:

- Prevents using both `-as` and `--audio-default-only` together
- Prevents using both `--keep-other-audio` and `--keep-original-audio` together

Tests:

- Added 6 new test cases covering all scenarios
- All 46 tests passing (40 original + 6 new)

Documentation:

- Updated docs/usage/options.md with complete documentation for new options